### PR TITLE
Added AutoComplete attribute for typeahead

### DIFF
--- a/dist/amd/typeahead/aubs-typeahead.html
+++ b/dist/amd/typeahead/aubs-typeahead.html
@@ -4,7 +4,8 @@
 
     <div class="dropdown" ref="dropdown">
         <input class="form form-control ${inputClass}" placeholder.bind="placeholder" ref="input"
-               value.bind="filter & debounce:debounce" disabled.bind="disabled" id.bind="id">
+               value.bind="filter & debounce:debounce" disabled.bind="disabled" id.bind="id" 
+               autocomplete.bind="autoComplete ? 'on' : 'off'">
 
         <ul class="dropdown-menu" if.bind="!v4">
             <li show.bind="displayData.length === 0 && !loading" class="text-center">

--- a/dist/amd/typeahead/aubs-typeahead.js
+++ b/dist/amd/typeahead/aubs-typeahead.js
@@ -61,7 +61,7 @@ define(['exports', 'aurelia-framework', '../utils/bootstrap-options'], function 
         throw new Error('Decorating class property failed. Please ensure that transform-class-properties is enabled.');
     }
 
-    var _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6, _descriptor7, _descriptor8, _descriptor9, _descriptor10, _descriptor11, _descriptor12, _descriptor13, _descriptor14, _descriptor15, _descriptor16, _descriptor17, _descriptor18;
+    var _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6, _descriptor7, _descriptor8, _descriptor9, _descriptor10, _descriptor11, _descriptor12, _descriptor13, _descriptor14, _descriptor15, _descriptor16, _descriptor17, _descriptor18, _descriptor19;
 
     var AubsTypeaheadCustomElement = exports.AubsTypeaheadCustomElement = (_dec = (0, _aureliaFramework.inject)(_aureliaFramework.BindingEngine), _dec2 = (0, _aureliaFramework.bindable)({ defaultBindingMode: _aureliaFramework.bindingMode.twoWay }), _dec(_class = (0, _aureliaFramework.containerless)(_class = (_class2 = function () {
         function AubsTypeaheadCustomElement(bindingEngine) {
@@ -95,19 +95,21 @@ define(['exports', 'aurelia-framework', '../utils/bootstrap-options'], function 
 
             _initDefineProp(this, 'selectSingleResult', _descriptor13, this);
 
-            _initDefineProp(this, 'loadingText', _descriptor14, this);
+            _initDefineProp(this, 'autoComplete', _descriptor14, this);
 
-            _initDefineProp(this, 'inputClass', _descriptor15, this);
+            _initDefineProp(this, 'loadingText', _descriptor15, this);
 
-            _initDefineProp(this, 'placeholder', _descriptor16, this);
+            _initDefineProp(this, 'inputClass', _descriptor16, this);
 
-            _initDefineProp(this, 'noResultsText', _descriptor17, this);
+            _initDefineProp(this, 'placeholder', _descriptor17, this);
+
+            _initDefineProp(this, 'noResultsText', _descriptor18, this);
 
             this.promiseQueue = [];
             this.v4 = false;
             this.displayData = [];
 
-            _initDefineProp(this, 'filter', _descriptor18, this);
+            _initDefineProp(this, 'filter', _descriptor19, this);
 
             this.focusedIndex = -1;
             this.focusedItem = null;
@@ -488,27 +490,32 @@ define(['exports', 'aurelia-framework', '../utils/bootstrap-options'], function 
         initializer: function initializer() {
             return false;
         }
-    }), _descriptor14 = _applyDecoratedDescriptor(_class2.prototype, 'loadingText', [_aureliaFramework.bindable], {
+    }), _descriptor14 = _applyDecoratedDescriptor(_class2.prototype, 'autoComplete', [_aureliaFramework.bindable], {
+        enumerable: true,
+        initializer: function initializer() {
+            return false;
+        }
+    }), _descriptor15 = _applyDecoratedDescriptor(_class2.prototype, 'loadingText', [_aureliaFramework.bindable], {
         enumerable: true,
         initializer: function initializer() {
             return 'Loading...';
         }
-    }), _descriptor15 = _applyDecoratedDescriptor(_class2.prototype, 'inputClass', [_aureliaFramework.bindable], {
+    }), _descriptor16 = _applyDecoratedDescriptor(_class2.prototype, 'inputClass', [_aureliaFramework.bindable], {
         enumerable: true,
         initializer: function initializer() {
             return '';
         }
-    }), _descriptor16 = _applyDecoratedDescriptor(_class2.prototype, 'placeholder', [_aureliaFramework.bindable], {
+    }), _descriptor17 = _applyDecoratedDescriptor(_class2.prototype, 'placeholder', [_aureliaFramework.bindable], {
         enumerable: true,
         initializer: function initializer() {
             return '';
         }
-    }), _descriptor17 = _applyDecoratedDescriptor(_class2.prototype, 'noResultsText', [_aureliaFramework.bindable], {
+    }), _descriptor18 = _applyDecoratedDescriptor(_class2.prototype, 'noResultsText', [_aureliaFramework.bindable], {
         enumerable: true,
         initializer: function initializer() {
             return 'No Results';
         }
-    }), _descriptor18 = _applyDecoratedDescriptor(_class2.prototype, 'filter', [_aureliaFramework.observable], {
+    }), _descriptor19 = _applyDecoratedDescriptor(_class2.prototype, 'filter', [_aureliaFramework.observable], {
         enumerable: true,
         initializer: function initializer() {
             return '';

--- a/dist/commonjs/typeahead/aubs-typeahead.html
+++ b/dist/commonjs/typeahead/aubs-typeahead.html
@@ -4,7 +4,8 @@
 
     <div class="dropdown" ref="dropdown">
         <input class="form form-control ${inputClass}" placeholder.bind="placeholder" ref="input"
-               value.bind="filter & debounce:debounce" disabled.bind="disabled" id.bind="id">
+               value.bind="filter & debounce:debounce" disabled.bind="disabled" id.bind="id" 
+               autocomplete.bind="autoComplete ? 'on' : 'off'">
 
         <ul class="dropdown-menu" if.bind="!v4">
             <li show.bind="displayData.length === 0 && !loading" class="text-center">

--- a/dist/commonjs/typeahead/aubs-typeahead.js
+++ b/dist/commonjs/typeahead/aubs-typeahead.js
@@ -7,7 +7,7 @@ exports.AubsTypeaheadCustomElement = undefined;
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-var _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6, _descriptor7, _descriptor8, _descriptor9, _descriptor10, _descriptor11, _descriptor12, _descriptor13, _descriptor14, _descriptor15, _descriptor16, _descriptor17, _descriptor18;
+var _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6, _descriptor7, _descriptor8, _descriptor9, _descriptor10, _descriptor11, _descriptor12, _descriptor13, _descriptor14, _descriptor15, _descriptor16, _descriptor17, _descriptor18, _descriptor19;
 
 var _aureliaFramework = require('aurelia-framework');
 
@@ -90,19 +90,21 @@ var AubsTypeaheadCustomElement = exports.AubsTypeaheadCustomElement = (_dec = (0
 
         _initDefineProp(this, 'selectSingleResult', _descriptor13, this);
 
-        _initDefineProp(this, 'loadingText', _descriptor14, this);
+        _initDefineProp(this, 'autoComplete', _descriptor14, this);
 
-        _initDefineProp(this, 'inputClass', _descriptor15, this);
+        _initDefineProp(this, 'loadingText', _descriptor15, this);
 
-        _initDefineProp(this, 'placeholder', _descriptor16, this);
+        _initDefineProp(this, 'inputClass', _descriptor16, this);
 
-        _initDefineProp(this, 'noResultsText', _descriptor17, this);
+        _initDefineProp(this, 'placeholder', _descriptor17, this);
+
+        _initDefineProp(this, 'noResultsText', _descriptor18, this);
 
         this.promiseQueue = [];
         this.v4 = false;
         this.displayData = [];
 
-        _initDefineProp(this, 'filter', _descriptor18, this);
+        _initDefineProp(this, 'filter', _descriptor19, this);
 
         this.focusedIndex = -1;
         this.focusedItem = null;
@@ -483,27 +485,32 @@ var AubsTypeaheadCustomElement = exports.AubsTypeaheadCustomElement = (_dec = (0
     initializer: function initializer() {
         return false;
     }
-}), _descriptor14 = _applyDecoratedDescriptor(_class2.prototype, 'loadingText', [_aureliaFramework.bindable], {
+}), _descriptor14 = _applyDecoratedDescriptor(_class2.prototype, 'autoComplete', [_aureliaFramework.bindable], {
+    enumerable: true,
+    initializer: function initializer() {
+        return false;
+    }
+}), _descriptor15 = _applyDecoratedDescriptor(_class2.prototype, 'loadingText', [_aureliaFramework.bindable], {
     enumerable: true,
     initializer: function initializer() {
         return 'Loading...';
     }
-}), _descriptor15 = _applyDecoratedDescriptor(_class2.prototype, 'inputClass', [_aureliaFramework.bindable], {
+}), _descriptor16 = _applyDecoratedDescriptor(_class2.prototype, 'inputClass', [_aureliaFramework.bindable], {
     enumerable: true,
     initializer: function initializer() {
         return '';
     }
-}), _descriptor16 = _applyDecoratedDescriptor(_class2.prototype, 'placeholder', [_aureliaFramework.bindable], {
+}), _descriptor17 = _applyDecoratedDescriptor(_class2.prototype, 'placeholder', [_aureliaFramework.bindable], {
     enumerable: true,
     initializer: function initializer() {
         return '';
     }
-}), _descriptor17 = _applyDecoratedDescriptor(_class2.prototype, 'noResultsText', [_aureliaFramework.bindable], {
+}), _descriptor18 = _applyDecoratedDescriptor(_class2.prototype, 'noResultsText', [_aureliaFramework.bindable], {
     enumerable: true,
     initializer: function initializer() {
         return 'No Results';
     }
-}), _descriptor18 = _applyDecoratedDescriptor(_class2.prototype, 'filter', [_aureliaFramework.observable], {
+}), _descriptor19 = _applyDecoratedDescriptor(_class2.prototype, 'filter', [_aureliaFramework.observable], {
     enumerable: true,
     initializer: function initializer() {
         return '';

--- a/dist/es2015/typeahead/aubs-typeahead.html
+++ b/dist/es2015/typeahead/aubs-typeahead.html
@@ -4,7 +4,8 @@
 
     <div class="dropdown" ref="dropdown">
         <input class="form form-control ${inputClass}" placeholder.bind="placeholder" ref="input"
-               value.bind="filter & debounce:debounce" disabled.bind="disabled" id.bind="id">
+               value.bind="filter & debounce:debounce" disabled.bind="disabled" id.bind="id" 
+               autocomplete.bind="autoComplete ? 'on' : 'off'">
 
         <ul class="dropdown-menu" if.bind="!v4">
             <li show.bind="displayData.length === 0 && !loading" class="text-center">

--- a/dist/es2015/typeahead/aubs-typeahead.js
+++ b/dist/es2015/typeahead/aubs-typeahead.js
@@ -1,4 +1,4 @@
-var _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6, _descriptor7, _descriptor8, _descriptor9, _descriptor10, _descriptor11, _descriptor12, _descriptor13, _descriptor14, _descriptor15, _descriptor16, _descriptor17, _descriptor18;
+var _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6, _descriptor7, _descriptor8, _descriptor9, _descriptor10, _descriptor11, _descriptor12, _descriptor13, _descriptor14, _descriptor15, _descriptor16, _descriptor17, _descriptor18, _descriptor19;
 
 function _initDefineProp(target, property, descriptor, context) {
     if (!descriptor) return;
@@ -75,19 +75,21 @@ export let AubsTypeaheadCustomElement = (_dec = inject(BindingEngine), _dec2 = b
 
         _initDefineProp(this, 'selectSingleResult', _descriptor13, this);
 
-        _initDefineProp(this, 'loadingText', _descriptor14, this);
+        _initDefineProp(this, 'autoComplete', _descriptor14, this);
 
-        _initDefineProp(this, 'inputClass', _descriptor15, this);
+        _initDefineProp(this, 'loadingText', _descriptor15, this);
 
-        _initDefineProp(this, 'placeholder', _descriptor16, this);
+        _initDefineProp(this, 'inputClass', _descriptor16, this);
 
-        _initDefineProp(this, 'noResultsText', _descriptor17, this);
+        _initDefineProp(this, 'placeholder', _descriptor17, this);
+
+        _initDefineProp(this, 'noResultsText', _descriptor18, this);
 
         this.promiseQueue = [];
         this.v4 = false;
         this.displayData = [];
 
-        _initDefineProp(this, 'filter', _descriptor18, this);
+        _initDefineProp(this, 'filter', _descriptor19, this);
 
         this.focusedIndex = -1;
         this.focusedItem = null;
@@ -444,27 +446,32 @@ export let AubsTypeaheadCustomElement = (_dec = inject(BindingEngine), _dec2 = b
     initializer: function () {
         return false;
     }
-}), _descriptor14 = _applyDecoratedDescriptor(_class2.prototype, 'loadingText', [bindable], {
+}), _descriptor14 = _applyDecoratedDescriptor(_class2.prototype, 'autoComplete', [bindable], {
+    enumerable: true,
+    initializer: function () {
+        return false;
+    }
+}), _descriptor15 = _applyDecoratedDescriptor(_class2.prototype, 'loadingText', [bindable], {
     enumerable: true,
     initializer: function () {
         return 'Loading...';
     }
-}), _descriptor15 = _applyDecoratedDescriptor(_class2.prototype, 'inputClass', [bindable], {
+}), _descriptor16 = _applyDecoratedDescriptor(_class2.prototype, 'inputClass', [bindable], {
     enumerable: true,
     initializer: function () {
         return '';
     }
-}), _descriptor16 = _applyDecoratedDescriptor(_class2.prototype, 'placeholder', [bindable], {
+}), _descriptor17 = _applyDecoratedDescriptor(_class2.prototype, 'placeholder', [bindable], {
     enumerable: true,
     initializer: function () {
         return '';
     }
-}), _descriptor17 = _applyDecoratedDescriptor(_class2.prototype, 'noResultsText', [bindable], {
+}), _descriptor18 = _applyDecoratedDescriptor(_class2.prototype, 'noResultsText', [bindable], {
     enumerable: true,
     initializer: function () {
         return 'No Results';
     }
-}), _descriptor18 = _applyDecoratedDescriptor(_class2.prototype, 'filter', [observable], {
+}), _descriptor19 = _applyDecoratedDescriptor(_class2.prototype, 'filter', [observable], {
     enumerable: true,
     initializer: function () {
         return '';

--- a/dist/system/typeahead/aubs-typeahead.html
+++ b/dist/system/typeahead/aubs-typeahead.html
@@ -4,7 +4,8 @@
 
     <div class="dropdown" ref="dropdown">
         <input class="form form-control ${inputClass}" placeholder.bind="placeholder" ref="input"
-               value.bind="filter & debounce:debounce" disabled.bind="disabled" id.bind="id">
+               value.bind="filter & debounce:debounce" disabled.bind="disabled" id.bind="id" 
+               autocomplete.bind="autoComplete ? 'on' : 'off'">
 
         <ul class="dropdown-menu" if.bind="!v4">
             <li show.bind="displayData.length === 0 && !loading" class="text-center">

--- a/dist/system/typeahead/aubs-typeahead.js
+++ b/dist/system/typeahead/aubs-typeahead.js
@@ -3,7 +3,7 @@
 System.register(['aurelia-framework', '../utils/bootstrap-options'], function (_export, _context) {
     "use strict";
 
-    var inject, bindable, bindingMode, observable, BindingEngine, containerless, bootstrapOptions, _typeof, _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6, _descriptor7, _descriptor8, _descriptor9, _descriptor10, _descriptor11, _descriptor12, _descriptor13, _descriptor14, _descriptor15, _descriptor16, _descriptor17, _descriptor18, AubsTypeaheadCustomElement;
+    var inject, bindable, bindingMode, observable, BindingEngine, containerless, bootstrapOptions, _typeof, _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, _descriptor5, _descriptor6, _descriptor7, _descriptor8, _descriptor9, _descriptor10, _descriptor11, _descriptor12, _descriptor13, _descriptor14, _descriptor15, _descriptor16, _descriptor17, _descriptor18, _descriptor19, AubsTypeaheadCustomElement;
 
     function _initDefineProp(target, property, descriptor, context) {
         if (!descriptor) return;
@@ -104,19 +104,21 @@ System.register(['aurelia-framework', '../utils/bootstrap-options'], function (_
 
                     _initDefineProp(this, 'selectSingleResult', _descriptor13, this);
 
-                    _initDefineProp(this, 'loadingText', _descriptor14, this);
+                    _initDefineProp(this, 'autoComplete', _descriptor14, this);
 
-                    _initDefineProp(this, 'inputClass', _descriptor15, this);
+                    _initDefineProp(this, 'loadingText', _descriptor15, this);
 
-                    _initDefineProp(this, 'placeholder', _descriptor16, this);
+                    _initDefineProp(this, 'inputClass', _descriptor16, this);
 
-                    _initDefineProp(this, 'noResultsText', _descriptor17, this);
+                    _initDefineProp(this, 'placeholder', _descriptor17, this);
+
+                    _initDefineProp(this, 'noResultsText', _descriptor18, this);
 
                     this.promiseQueue = [];
                     this.v4 = false;
                     this.displayData = [];
 
-                    _initDefineProp(this, 'filter', _descriptor18, this);
+                    _initDefineProp(this, 'filter', _descriptor19, this);
 
                     this.focusedIndex = -1;
                     this.focusedItem = null;
@@ -497,27 +499,32 @@ System.register(['aurelia-framework', '../utils/bootstrap-options'], function (_
                 initializer: function initializer() {
                     return false;
                 }
-            }), _descriptor14 = _applyDecoratedDescriptor(_class2.prototype, 'loadingText', [bindable], {
+            }), _descriptor14 = _applyDecoratedDescriptor(_class2.prototype, 'autoComplete', [bindable], {
+                enumerable: true,
+                initializer: function initializer() {
+                    return false;
+                }
+            }), _descriptor15 = _applyDecoratedDescriptor(_class2.prototype, 'loadingText', [bindable], {
                 enumerable: true,
                 initializer: function initializer() {
                     return 'Loading...';
                 }
-            }), _descriptor15 = _applyDecoratedDescriptor(_class2.prototype, 'inputClass', [bindable], {
+            }), _descriptor16 = _applyDecoratedDescriptor(_class2.prototype, 'inputClass', [bindable], {
                 enumerable: true,
                 initializer: function initializer() {
                     return '';
                 }
-            }), _descriptor16 = _applyDecoratedDescriptor(_class2.prototype, 'placeholder', [bindable], {
+            }), _descriptor17 = _applyDecoratedDescriptor(_class2.prototype, 'placeholder', [bindable], {
                 enumerable: true,
                 initializer: function initializer() {
                     return '';
                 }
-            }), _descriptor17 = _applyDecoratedDescriptor(_class2.prototype, 'noResultsText', [bindable], {
+            }), _descriptor18 = _applyDecoratedDescriptor(_class2.prototype, 'noResultsText', [bindable], {
                 enumerable: true,
                 initializer: function initializer() {
                     return 'No Results';
                 }
-            }), _descriptor18 = _applyDecoratedDescriptor(_class2.prototype, 'filter', [observable], {
+            }), _descriptor19 = _applyDecoratedDescriptor(_class2.prototype, 'filter', [observable], {
                 enumerable: true,
                 initializer: function initializer() {
                     return '';

--- a/src/typeahead/aubs-typeahead.html
+++ b/src/typeahead/aubs-typeahead.html
@@ -4,7 +4,8 @@
 
     <div class="dropdown" ref="dropdown">
         <input class="form form-control ${inputClass}" placeholder.bind="placeholder" ref="input"
-               value.bind="filter & debounce:debounce" disabled.bind="disabled" id.bind="id">
+               value.bind="filter & debounce:debounce" disabled.bind="disabled" id.bind="id" 
+               autocomplete.bind="autoComplete ? 'on' : 'off'">
 
         <ul class="dropdown-menu" if.bind="!v4">
             <li show.bind="displayData.length === 0 && !loading" class="text-center">

--- a/src/typeahead/aubs-typeahead.js
+++ b/src/typeahead/aubs-typeahead.js
@@ -17,6 +17,7 @@ export class AubsTypeaheadCustomElement {
     @bindable openOnFocus = false;
     @bindable focusFirst = true;
     @bindable selectSingleResult = false;
+    @bindable autoComplete = false;
     @bindable loadingText = 'Loading...';
     @bindable inputClass = '';
     @bindable placeholder = '';


### PR DESCRIPTION
Added a autoComplete attribute on the typeahead module to allowe browser autocompletion to be disabled for the input field. Defaults to turning autocomplete off as it interferes with the dropdown